### PR TITLE
FIX: Add Vue configuration with defined public path.

### DIFF
--- a/vue.config.ts
+++ b/vue.config.ts
@@ -1,0 +1,3 @@
+module.exports = {
+    publicPath: '/repo/', 
+  };


### PR DESCRIPTION
This pull request introduces a small change to the `vue.config.ts` file. It sets the `publicPath` to `/repo/` to configure the base URL for the application when deployed.